### PR TITLE
refactor:get_object_or_404 적용

### DIFF
--- a/form/serializers.py
+++ b/form/serializers.py
@@ -12,10 +12,8 @@ class FormInvitedSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'user']
     
     def validate_uuid(self, value):
-        try:
-            form = Form.objects.get(uuid=value)
-        except ObjectDoesNotExist:
-            raise serializers.ValidationError("유효하지 않은 UUID 입니다.")
+        form = get_object_or_404(Form, uuid=value)
+        
         return form
     
     def validate_user(self, value):


### PR DESCRIPTION
get으로 조회를 하는 경우 반환값이 없어 DoseNotExist예외처리 필수
get_object_or_404의 경우 get과 동일 하지만 예외처리 자동!, But 여러값이 있는 경우 MultipleObjectsReturned 예외 처리 필요
first로 조회를 하는 경우 None을 반환하기 때문에 예외가 발생하지 않는다. 여러 값이 있을수도 있는 경우 first가 안전할수도 있기에 상황에 맞게 사용해야 한다. 

