### PR TITLE
hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ django-crontab = "^0.7.1"
 poetry = "1.8.4"
 django-storages = "^1.14.4"
 boto3 = "^1.35.95"
+django-cors-headers = "^4.6.0"
 
 
 


### PR DESCRIPTION
- django-cors-headers 설치누락